### PR TITLE
Add /opt/td-agent/embedded/bin/ on PATH

### DIFF
--- a/lib/puppet/provider/package/fluentgem.rb
+++ b/lib/puppet/provider/package/fluentgem.rb
@@ -14,7 +14,7 @@ Puppet::Type.type(:package).provide :fluentgem, :parent => Puppet::Provider::Pac
 
   has_feature :versionable, :install_options
 
-  ENV['PATH'] = "#{ENV['PATH']}:/usr/lib64/fluent/ruby/bin:/usr/lib/fluent/ruby/bin"
+  ENV['PATH'] = "#{ENV['PATH']}:/usr/lib64/fluent/ruby/bin:/usr/lib/fluent/ruby/bin:/opt/td-agent/embedded/bin"
 
   commands :gemcmd => "fluent-gem"
 


### PR DESCRIPTION
Because since td-agent 2.x, Omnibus package base install is in /opt/tdagent (https://github.com/treasure-data/omnibus-td-agent/releases).